### PR TITLE
Update image twice a month

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 1 * *" # the 1st of every month
+    - cron: "0 0 1,15 * *" # the 1st and 15th of every month
 
 env:
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Currently, we update the image once a month, and we are getting warning messages to update. This PR makes the update twice a month.

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/c8e87f4b-c509-47bd-88c7-6b067a141a36">
