### PR TITLE
Set home directory to be world-readable

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -34,9 +34,6 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 1,15 * *" # the 1st and 15th of every month
 
@@ -22,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Log in to the Container registry
         uses: docker/login-action@40891eba8c2bcd1309b07ba8b11232f313e86779
@@ -31,11 +34,20 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e
         with:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
 
       - name: Build and push Docker image
         uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,7 @@ USER runner
 
 # Used for uploading/downloading artifacts
 RUN python3 -m pip install s3cmd
+
+# Make everything in the home directory readable by everyone.
+# This facilitates using the image when unpacked with ducc: https://github.com/cvmfs/cvmfs/tree/cd523a3241878c697aba7e3bee43c76a3dc11ebc/ducc
+RUN find $HOME -type d -exec chmod o+rx {} \; && find $HOME -type f -exec chmod o+r {} \;


### PR DESCRIPTION
When using this image with unpacked.cern.ch (https://github.com/cvmfs/images-unpacked.cern.ch/pull/29), the files are unpacked without uidmap. This causes the runner home directory to only be readable by the runner user (uid 1001 at the time of writing). We want to use this image in a rootless environment. This PR makes it so that the runner home directory is world-readable. This is kinda hacky, but worth experimenting with.