### PR TITLE
Install bc

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 1,15 * *" # the 1st and 15th of every month
 
@@ -22,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Log in to the Container registry
         uses: docker/login-action@40891eba8c2bcd1309b07ba8b11232f313e86779

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -y \
     openssh-client \
     build-essential \
     zstd \
+    bc \
     && rm -rf /var/lib/apt/lists/*
 
 # Download latest git-lfs version


### PR DESCRIPTION
Install `bc` in the runner container so that we don't need to install it in jobs. There has been a lot of ci failures in `apt install bc` for some reason. https://github.com/WATonomous/infra-config/issues/4371