### PR TITLE
Add note about CVMFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # actions-runner-image
 
 This repo contains a derivation of the official [actions/runner](https://github.com/actions/runner) image to use in self-hosted GitHub Actions runners.
+
+The image created in this repo is [automatically unpacked and served](https://github.com/cvmfs/images-unpacked.cern.ch/pull/29) via the [unpacked.cern.ch CVMFS repo](https://github.com/cvmfs/images-unpacked.cern.ch), which is updated hourly as of 2025-05-31. The CERN CI pipeline status and logs are available [here](https://lcgapp-services.cern.ch/cvmfs-jenkins/view/CVMFS/job/unpacked.cern.ch/) (requires a CERN account. Guest accounts can be created by anyone).


### PR DESCRIPTION
This PR adds a note about CVMFS, so that in the future, issues with the runner image can be more easily debugged.